### PR TITLE
Do not manipulate the external programs' outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,17 +23,6 @@ repos:
         exclude: ^tests/
         additional_dependencies: ["tomli"]
 
-  - repo: https://github.com/pycqa/isort
-    rev: "5.13.2"
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
-  - repo: https://github.com/psf/black
-    rev: "23.12.1"
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.8.0"
     hooks:
@@ -42,7 +31,7 @@ repos:
         exclude: ^tests/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.9"
+    rev: "v0.1.14"
     hooks:
       - id: ruff
         args: [--fix]

--- a/dosh_core/commands/base.py
+++ b/dosh_core/commands/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import functools
 import platform
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -109,3 +110,11 @@ def copy_tree(src: Path, dst: Path) -> None:
     else:
         logger.info("COPY FILE: %s -> %s", src, dst)
         shutil.copy(src, dst)
+
+
+def run_command_and_return_result(content: str, log_prefix: str = "") -> int:
+    """Run external command and return result with the captured output."""
+    result = subprocess.run(content, shell=True)
+    return_code = result.returncode
+    logger.debug("%s Return code: %s".strip(), log_prefix, return_code)
+    return return_code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dosh-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shell-independent task management library."
 authors = ["Gökmen Görgen <gkmngrgn@gmail.com>"]
 readme = "README.md"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -48,7 +48,7 @@ def test_run(caplog):
     result = cmd.run("echo Hello!")
     assert result == 0
     assert caplog.records[0].message == "[RUN] echo Hello!"
-    assert caplog.records[1].message == "Hello!"
+    assert caplog.records[1].message == "[RUN] Return code: 0"
 
 
 def test_run_url(httpserver, caplog):
@@ -71,7 +71,7 @@ def test_run_url(httpserver, caplog):
         caplog.records[2].message
         == f"[RUN_URL] http://{httpserver.host}:{httpserver.port}/hello.sh"
     )
-    assert caplog.records[3].message == "Hello!"
+    assert caplog.records[3].message == "[RUN_URL] Return code: 0"
 
 
 def test_exists(tmp_path):


### PR DESCRIPTION
Most of programs like docker, pre-commit, any nodejs cli tool do not follow traditional rules about writing cli, so I disabled to capture the outputs and reprint them.

Now DOSH just prepares the command for the execution and runs it in shell.