### PR TITLE
#70 add a new parameter for install_dir. also warn user if install dir is…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 Our GitHub Actions workflow builds app for these operating systems:
 
 - Linux (aarch64, x86_64)
-- MacOS (x86_64)
+- MacOS (arm64)
 - Windows (amd64)
 
-### BASH (for Linux, MacOS)
+### For Linux and MacOS
 
 ```shell
-sh <(curl https://raw.githubusercontent.com/gkmngrgn/dosh/main/install.sh)
+sh <(curl https://raw.githubusercontent.com/gkmngrgn/dosh/main/install.sh) --install-dir $HOME/.local/bin
 ```
 
-### POWERSHELL (for Windows)
+### For Windows (PowerShell)
 
 ```powershell
 iwr https://raw.githubusercontent.com/gkmngrgn/dosh/main/install.ps1 -useb | iex

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@ install_dir="$HOME/.local/bin"
 while [ $# -gt 0 ]; do
   case "$1" in
     --install-dir)
+      if [ -z "$2" ]; then
+        echo "Error: --install-dir requires a value" >&2
+        exit 1
+      fi
       install_dir="$2"
       shift # past argument
       shift # past value

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,11 @@ while [ $# -gt 0 ]; do
       install_dir="$2"
       shift # past argument
       shift # past value
-      ;; 
+      ;;
     *)
       # unknown option
       shift # past argument
-      ;; 
+      ;;
   esac
 done
 

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,55 @@
 #!/bin/sh
 set -e
 
+# Default installation directory
+install_dir="$HOME/.local/bin"
+
+# Parse command-line arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      install_dir="$2"
+      shift # past argument
+      shift # past value
+      ;; 
+    *)
+      # unknown option
+      shift # past argument
+      ;; 
+  esac
+done
+
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 architecture=$(uname -m)
 download_url="https://github.com/gkmngrgn/dosh/releases/latest/download/dosh-$os-$architecture"
 temp_dir=$(mktemp -d)
-local_dir="$HOME/.local"
-bin_file="$local_dir/bin/dosh"
+bin_file="$install_dir/dosh"
 
 echo "Operating System: $os"
 echo "Architecture: $architecture"
 echo "Temporary directory: $temp_dir"
 echo "Download URL: $download_url"
+echo "Installation directory: $install_dir"
 
 printf "\nSTEP 1: Downloading DOSH...\n"
 curl -L "$download_url" -o "$temp_dir/dosh"
 
-printf "\nSTEP 2: Installing DOSH CLI...\n"
+printf "\nSTEP 2: Installing DOSH CLI to %s...\n" "$bin_file"
 if [ -f "$bin_file" ]; then
     mv "$bin_file" "$temp_dir/dosh.old"
 else
     # make sure if local bin folder exists
-    mkdir -p "$local_dir/bin"
+    mkdir -p "$install_dir"
 fi
 
 mv "$temp_dir/dosh" "$bin_file"
 chmod +x "$bin_file"
+
+if ! echo "$PATH" | grep -q "$install_dir"; then
+    printf "\n\033[1;33mWARNING: '%s' is not in your PATH.\033[0m" "$install_dir"
+    printf "\n\033[1;33mYou should add the following line to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc):\033[0m\n"
+    printf '\n\033[1;33m  export PATH="%s:$PATH"\033[0m\n' "$install_dir"
+fi
 
 printf "\nSTEP 3: Done! You can delete the temporary directory if you want:"
 printf "\n%s\n" "$temp_dir"

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,11 @@ fi
 mv "$temp_dir/dosh" "$bin_file"
 chmod +x "$bin_file"
 
-if ! echo ":$PATH:" | grep -q ":$install_dir:"; then
+# Expand install_dir to absolute path for PATH comparison
+# This handles cases where user provides ~/bin but PATH has /home/user/bin
+expanded_install_dir=$(cd "$install_dir" 2>/dev/null && pwd) || expanded_install_dir="$install_dir"
+
+if ! echo ":$PATH:" | grep -q ":$expanded_install_dir:" && ! echo ":$PATH:" | grep -q ":$install_dir:"; then
     printf "\n\033[1;33mWARNING: '%s' is not in your PATH.\033[0m" "$install_dir"
     printf "\n\033[1;33mYou should add the following line to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc):\033[0m\n"
     printf '\n\033[1;33m  export PATH="%s:$PATH"\033[0m\n' "$install_dir"

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ fi
 mv "$temp_dir/dosh" "$bin_file"
 chmod +x "$bin_file"
 
-if ! echo "$PATH" | grep -q "$install_dir"; then
+if ! echo ":$PATH:" | grep -q ":$install_dir:"; then
     printf "\n\033[1;33mWARNING: '%s' is not in your PATH.\033[0m" "$install_dir"
     printf "\n\033[1;33mYou should add the following line to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc):\033[0m\n"
     printf '\n\033[1;33m  export PATH="%s:$PATH"\033[0m\n' "$install_dir"


### PR DESCRIPTION
… not in $PATH list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable install directory to installer with PATH warning and updates README (MacOS arm64, revised install commands).
> 
> - **Install script (`install.sh`)**:
>   - Add `--install-dir` argument (default `~/.local/bin`) and install to `bin_file="$install_dir/dosh"`.
>   - Print chosen installation directory; ensure directory creation with `mkdir -p "$install_dir"`.
>   - Expand `install_dir` for robust PATH check and warn user if not present; suggest export line.
>   - Minor messaging tweaks for steps and targets.
> - **Docs (`README.md`)**:
>   - Add MacOS `arm64` to supported builds.
>   - Update Linux/MacOS install command to include `--install-dir $HOME/.local/bin`.
>   - Clarify platform section headings (Linux/MacOS, Windows PowerShell).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8405ebcbf36779318dade62f2684875382c38c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->